### PR TITLE
update units font size

### DIFF
--- a/BulletGraph.R
+++ b/BulletGraph.R
@@ -145,7 +145,7 @@ gridBulletGraphH <- function(bgData, nticks=3, format="s", bcol=c("red", "yellow
     pushViewport(vp)
     grid.text(label = bgData$units[i],
               just  = "right", 
-              gp    = gpar(fontsize=font, col="black"), 
+              gp    = gpar(fontsize=scfont, col="black"), 
               x     = .9,
               y     = .5)
     upViewport(n=5)
@@ -299,7 +299,7 @@ gridBulletGraphV <- function(bgData, nticks=3, format="s", bcol=c("red", "yellow
     pushViewport(vp)
     grid.text(label = bgData$units[i],
               just  = "bottom", 
-              gp    = gpar(fontsize=font, col="black"), 
+              gp    = gpar(fontsize=scfont, col="black"), 
               x     = .5,
               y     = .5)
     upViewport(n=5)


### PR DESCRIPTION
units font size is rendering as the same size as the measurements. The input variable scfont sets this as smaller, so I've updated lines 148 & 302 to make the units show smaller on the plot.